### PR TITLE
Update for latest redis py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # No, Maybe and Close Enough!
 
-Exploring Probabilistic Data Structures in Python - my 2021 Pycon USA talk.  If you'd like to see the slides for this talk, they're [here](https://simonprickett.dev/no_maybe_and_close_enough_slides.pdf) (PDF).  Watch the video [here](https://www.youtube.com/watch?v=hM1JPkEUtks).
+Exploring Probabilistic Data Structures in Python - my 2021 Pycon USA and Australia talk.  I've updated the code slightly for Pycon 2022 - it now uses the latest redis-py Redis client.
 
-This repository contains supporting code to run the examples from my talk.  The example code uses in memory probabilistic data structures with the [hyperloglog](https://pypi.org/project/hyperloglog/) and [pyprobables](https://pypi.org/project/pyprobables/) libraries.  It also uses [Redis](https://redis.io) with the [RedisBloom](https://redisbloom.io) module: this is provided for you as a Docker container.
+If you'd like to see the slides for the 2021 version of this talk, they're [here](https://simonprickett.dev/no_maybe_and_close_enough_slides.pdf) (PDF).  Watch the 2021 video [here](https://www.youtube.com/watch?v=hM1JPkEUtks).
+
+This repository contains supporting code to run the examples from my talk.  The example code uses in memory probabilistic data structures with the [hyperloglog](https://pypi.org/project/hyperloglog/) and [pyprobables](https://pypi.org/project/pyprobables/) libraries.  It also uses [Redis](https://redis.io) with the [RedisBloom](https://redisbloom.io) module: this is provided for you as part of [Redis Stack](https://redis.io/docs/stack/get-started/) in a Docker container.
 
 The two probabilistic data structures examined in this code base are:
 
@@ -70,7 +72,7 @@ Approximate count with Python in memory HyperLogLog, compares count with an in m
 
 ```bash
 (venv) $ cd ../approximating_sheep_python
-(venv) $ python3 how_many.py
+(venv) $ python how_many.py
 There are 100000 sheep (set).
 There are 100075 sheep (hyperloglog).
 ```

--- a/approximating_sheep_redis/have_i_seen_this_one.py
+++ b/approximating_sheep_redis/have_i_seen_this_one.py
@@ -5,14 +5,14 @@ redis_conn = Redis()
 SHEEP_BLOOM_KEY = "sheep_seen_bloom"
 
 redis_conn.delete(SHEEP_BLOOM_KEY)
-redis_conn.execute_command("BF.RESERVE", SHEEP_BLOOM_KEY, "0.001", 200000)
+redis_conn.bf().create(SHEEP_BLOOM_KEY, 0.001, 200000, noScale = True)
 
 for m in range(0, 100000):
     sheep_id = str(m)
-    redis_conn.execute_command("BF.ADD", SHEEP_BLOOM_KEY, sheep_id)
+    redis_conn.bf().add(SHEEP_BLOOM_KEY, sheep_id)
 
 def have_i_seen(sheep_id):
-    if redis_conn.execute_command("BF.EXISTS", SHEEP_BLOOM_KEY, sheep_id):
+    if redis_conn.bf().exists(SHEEP_BLOOM_KEY, sheep_id):
         print(f"I might have seen sheep {sheep_id}.")
     else:
         print(f"I have not seen sheep {sheep_id}.")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,9 @@ version: "3.9"
 services:
   redis:
     container_name: redisprobabilistic
-    image: "redislabs/redismod"
+    image: "redis/redis-stack:latest"
     ports:
       - 6379:6379
-    entrypoint:
-      redis-server
-        --loadmodule /usr/lib/redis/modules/redisbloom.so
-        --appendonly yes
     deploy:
       replicas: 1
       restart_policy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-hyperloglog==0.0.12
-pyprobables==0.4.0
-redis==3.5.3
+async-timeout==4.0.2
+Deprecated==1.2.13
+hyperloglog==0.0.13
+packaging==21.3
+pyparsing==3.0.9
+pyprobables==0.5.6
+redis==4.3.4
+wrapt==1.14.1


### PR DESCRIPTION
Updated for advances in the redis-py client, no longer need to use `execute_command` to send RedisBloom commands.